### PR TITLE
Added window.orientation to CompassBearing.js

### DIFF
--- a/src/map/handler/Map.CompassBearing.js
+++ b/src/map/handler/Map.CompassBearing.js
@@ -12,7 +12,7 @@ L.Map.CompassBearing = L.Handler.extend({
 		this._capable = true;
 		this._map = map;
 
-		this._throttled = L.Util.throttle(this._onDeviceOrientation, 100, this);
+		this._throttled = L.Util.throttle(this._onDeviceOrientation, 1000, this);
 	},
 
 	addHooks: function () {
@@ -29,7 +29,7 @@ L.Map.CompassBearing = L.Handler.extend({
 
 	_onDeviceOrientation: function(event) {
 		if (event.alpha !== null) {
-			this._map.setBearing(event.alpha);
+			this._map.setBearing(event.alpha - window.orientation);
 		}
 	}
 });


### PR DESCRIPTION
To handle mobile device rotation added window.orientation to the setBearing function.
Increased the throttle time to 1000 (1s) produces better visual display on mobile device.
