### PR TITLE
[replaced] Zero-Rotating Marker/Popup/Tooltip Pane

### DIFF
--- a/debug/rotate/rotate-and-drag.html
+++ b/debug/rotate/rotate-and-drag.html
@@ -60,8 +60,10 @@
 		marker1.bindPopup(loremIpsum + '<p>Kyiv</p>').addTo(map);
 		marker2.bindPopup(loremIpsum + '<p>Lnd</p>').addTo(map);
 		marker3.bindPopup(loremIpsum + '<p>DC</p>').addTo(map);
-		marker4.bindPopup(loremIpsum + '<p>DF</p>').addTo(map);
+		marker4.bindPopup(loremIpsum + '<p>SF</p>').addTo(map);
 		marker5.bindPopup(loremIpsum + '<p>Trd</p>').addTo(map);
+
+		marker1.bindTooltip("Kyiv", {direction: 'right', permanent: true});
 
 		function rotate(ev) {
 			if (ev.buttons === 0) return;

--- a/debug/rotate/rotate-and-drag.html
+++ b/debug/rotate/rotate-and-drag.html
@@ -20,7 +20,7 @@
 
 	<div id="map"></div>
 
-	<input type="range" min="0" max="360" step="1" name="rho" id='rho_input' style='width:800px'/><span id='rho'></span>
+	<input type="range" min="0" max="360" value="0" step="1" name="rho" id='rho_input' style='width:800px'/><span id='rho'></span>
 
 	<div>
 		<button onclick="map.setBearing(0);" > 0</button>

--- a/debug/rotate/rotate.html
+++ b/debug/rotate/rotate.html
@@ -101,7 +101,7 @@
 			<td class='long'>Negative pixel coords of the (0,0) CRS point relative to _rotatePane</td></tr>
 	</table>
 
-	<input type="range" min="0" max="360" step="1" name="rho" id='rho_input' /><span id='rho'></span>
+	<input type="range" min="0" max="360" value="0" step="1" name="rho" id='rho_input' /><span id='rho'></span>
 
 	<div>
 		<button onclick="map.setBearing(0);" > 0</button>

--- a/debug/rotate/rotate.html
+++ b/debug/rotate/rotate.html
@@ -31,22 +31,22 @@
 		position:absolute;
 		width:1px;
 		height:1px;
-		border: 1px dotted green;
-		z-index: 100;
+		border: 2px solid red;
+		z-index: 9000;
 	}
 	div.pivot {
 		position:absolute;
 		width:1px;
 		height:1px;
-		border: 1px solid purple;
-		z-index: 100;
+		border: 2px solid purple;
+		z-index: 9000;
 	}
 	div.pixelorigin {
 		position:absolute;
 		width:1px;
 		height:1px;
-		border: 1px solid cyan;
-		z-index: 100;
+		border: 2px solid cyan;
+		z-index: 9000;
 	}
 	div.panebounds.main {
 		position:absolute;
@@ -147,19 +147,19 @@
 				.addLayer(osm)
 				.addLayer(path);
 
-		var marker1 = L.marker(kyiv).addTo(map),
-			marker2 = L.marker(lnd).addTo(map);
-			marker3 = L.marker(dc).addTo(map),
-			marker4 = L.marker(sf).addTo(map),
-			marker5 = L.marker(trd).addTo(map);
+		var marker1 = L.marker(kyiv).addTo(map);
+		//	marker2 = L.marker(lnd).addTo(map);
+		//	marker4 = L.marker(sf).addTo(map),
+		//	marker3 = L.marker(dc).addTo(map),
+		//	marker5 = L.marker(trd).addTo(map);
 
 		var loremIpsum = "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit, posuere a, pede.</p><p>Donec nec justo eget felis facilisis fermentum. Aliquam porttitor mauris sit amet orci. Aenean dignissim pellentesque.</p>";
 
 		marker1.bindPopup(loremIpsum + '<p>Kyiv</p>').addTo(map);
-		marker2.bindPopup(loremIpsum + '<p>Lnd</p>').addTo(map);
-		marker3.bindPopup(loremIpsum + '<p>DC</p>').addTo(map);
-		marker4.bindPopup(loremIpsum + '<p>DF</p>').addTo(map);
-		marker5.bindPopup(loremIpsum + '<p>Trd</p>').addTo(map);
+		//marker2.bindPopup(loremIpsum + '<p>Lnd</p>').addTo(map);
+		//marker3.bindPopup(loremIpsum + '<p>DC</p>').addTo(map);
+		//marker4.bindPopup(loremIpsum + '<p>DF</p>').addTo(map);
+		//marker5.bindPopup(loremIpsum + '<p>Trd</p>').addTo(map);
 
 
 		function logEvent(e) { console.log(e, e.type); }

--- a/debug/rotate/rotate.html
+++ b/debug/rotate/rotate.html
@@ -31,22 +31,22 @@
 		position:absolute;
 		width:1px;
 		height:1px;
-		border: 2px solid red;
-		z-index: 9000;
+		border: 1px dotted green;
+		z-index: 100;
 	}
 	div.pivot {
 		position:absolute;
 		width:1px;
 		height:1px;
-		border: 2px solid purple;
-		z-index: 9000;
+		border: 1px dotted purple;
+		z-index: 100;
 	}
 	div.pixelorigin {
 		position:absolute;
 		width:1px;
 		height:1px;
-		border: 2px solid cyan;
-		z-index: 9000;
+		border: 1px dotted cyan;
+		z-index: 100;
 	}
 	div.panebounds.main {
 		position:absolute;
@@ -147,10 +147,10 @@
 				.addLayer(osm)
 				.addLayer(path);
 
-		var marker1 = L.marker(kyiv).addTo(map);
-			marker2 = L.marker(lnd).addTo(map);
-			marker4 = L.marker(sf).addTo(map),
+		var marker1 = L.marker(kyiv).addTo(map),
+			marker2 = L.marker(lnd).addTo(map),
 			marker3 = L.marker(dc).addTo(map),
+			marker4 = L.marker(sf).addTo(map),
 			marker5 = L.marker(trd).addTo(map);
 
 		var loremIpsum = "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit, posuere a, pede.</p><p>Donec nec justo eget felis facilisis fermentum. Aliquam porttitor mauris sit amet orci. Aenean dignissim pellentesque.</p>";

--- a/debug/rotate/rotate.html
+++ b/debug/rotate/rotate.html
@@ -38,14 +38,14 @@
 		position:absolute;
 		width:1px;
 		height:1px;
-		border: 1px dotted purple;
+		border: 1px solid purple;
 		z-index: 100;
 	}
 	div.pixelorigin {
 		position:absolute;
 		width:1px;
 		height:1px;
-		border: 1px dotted cyan;
+		border: 1px solid cyan;
 		z-index: 100;
 	}
 	div.panebounds.main {

--- a/debug/rotate/rotate.html
+++ b/debug/rotate/rotate.html
@@ -148,18 +148,18 @@
 				.addLayer(path);
 
 		var marker1 = L.marker(kyiv).addTo(map);
-		//	marker2 = L.marker(lnd).addTo(map);
-		//	marker4 = L.marker(sf).addTo(map),
-		//	marker3 = L.marker(dc).addTo(map),
-		//	marker5 = L.marker(trd).addTo(map);
+			marker2 = L.marker(lnd).addTo(map);
+			marker4 = L.marker(sf).addTo(map),
+			marker3 = L.marker(dc).addTo(map),
+			marker5 = L.marker(trd).addTo(map);
 
 		var loremIpsum = "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit, posuere a, pede.</p><p>Donec nec justo eget felis facilisis fermentum. Aliquam porttitor mauris sit amet orci. Aenean dignissim pellentesque.</p>";
 
 		marker1.bindPopup(loremIpsum + '<p>Kyiv</p>').addTo(map);
-		//marker2.bindPopup(loremIpsum + '<p>Lnd</p>').addTo(map);
-		//marker3.bindPopup(loremIpsum + '<p>DC</p>').addTo(map);
-		//marker4.bindPopup(loremIpsum + '<p>DF</p>').addTo(map);
-		//marker5.bindPopup(loremIpsum + '<p>Trd</p>').addTo(map);
+		marker2.bindPopup(loremIpsum + '<p>Lnd</p>').addTo(map);
+		marker3.bindPopup(loremIpsum + '<p>DC</p>').addTo(map);
+		marker4.bindPopup(loremIpsum + '<p>DF</p>').addTo(map);
+		marker5.bindPopup(loremIpsum + '<p>Trd</p>').addTo(map);
 
 
 		function logEvent(e) { console.log(e, e.type); }

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -196,10 +196,17 @@ L.DomUtil = {
 		} else {
 			pos = pos.rotateFrom(bearing, pivot);
 
-			el.style[L.DomUtil.TRANSFORM] =
-				'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)' +
-				(scale ? ' scale(' + scale + ')' : '') +
-				' rotate(' + bearing + 'rad)';
+			if(el.classList.contains('leaflet-rotate-pane')) {
+				el.style[L.DomUtil.TRANSFORM] =
+					'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)' +
+					(scale ? ' scale(' + scale + ')' : '') +
+					' rotate(' + bearing + 'rad)';
+			}
+			else {
+				el.style[L.DomUtil.TRANSFORM] =
+					'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)' +
+					(scale ? ' scale(' + scale + ')' : '');
+			}
 		}
 	},
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -188,6 +188,7 @@ L.DomUtil = {
 		var pos = offset || new L.Point(0, 0);
 
 		if (!bearing) {
+			pos._round();
 			el.style[L.DomUtil.TRANSFORM] =
 				(L.Browser.ie3d ?
 				'translate(' + pos.x + 'px,' + pos.y + 'px)' :

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -197,18 +197,10 @@ L.DomUtil = {
 
 			pos = pos.rotateFrom(bearing, pivot);
 
-			if(el.classList.contains('leaflet-rotate-pane')) {
-				el.style[L.DomUtil.TRANSFORM] =
-					'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)' +
-					(scale ? ' scale(' + scale + ')' : '') +
-					' rotate(' + bearing + 'rad)';
-			}
-			else {
-				// console.log(pos);
-				el.style[L.DomUtil.TRANSFORM] =
-					'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)' +
-					(scale ? ' scale(' + scale + ')' : '');
-			}
+			el.style[L.DomUtil.TRANSFORM] =
+				'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)' +
+				(scale ? ' scale(' + scale + ')' : '') +
+				' rotate(' + bearing + 'rad)';
 		}
 	},
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -194,6 +194,7 @@ L.DomUtil = {
 				'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)') +
 				(scale ? ' scale(' + scale + ')' : '');
 		} else {
+
 			pos = pos.rotateFrom(bearing, pivot);
 
 			if(el.classList.contains('leaflet-rotate-pane')) {
@@ -203,6 +204,7 @@ L.DomUtil = {
 					' rotate(' + bearing + 'rad)';
 			}
 			else {
+				// console.log(pos);
 				el.style[L.DomUtil.TRANSFORM] =
 					'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)' +
 					(scale ? ' scale(' + scale + ')' : '');

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -194,7 +194,6 @@ L.DomUtil = {
 				'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)') +
 				(scale ? ' scale(' + scale + ')' : '');
 		} else {
-
 			pos = pos.rotateFrom(bearing, pivot);
 
 			el.style[L.DomUtil.TRANSFORM] =

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -124,12 +124,7 @@ L.Draggable = L.Evented.extend({
 
 		var first = (e.touches && e.touches.length === 1 ? e.touches[0] : e),
 		    newPoint = new L.Point(first.clientX, first.clientY),
-		    offset = newPoint.subtract(this._startPoint),
-		    bearing = this._mapBearing || 0;
-
-		if (bearing) {
-			offset = offset.rotate(-bearing);
-		}
+		    offset = newPoint.subtract(this._startPoint);
 
 		if (!offset.x && !offset.y) { return; }
 		if (Math.abs(offset.x) + Math.abs(offset.y) < this.options.clickTolerance) { return; }

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -183,8 +183,8 @@ L.DivOverlay = L.Layer.extend({
 		if (this._zoomAnimated) {
 			if (this._map._rotate) {
 				// rotation relative to the marker's anchor
-				var popupAnchor = pos.add([-this._containerLeft, this._container.offsetHeight + this._tipContainer.offsetHeight - offset.y]);
-				L.DomUtil.setPosition(this._container, pos.add(anchor), -this._map._bearing || 0, popupAnchor);
+				var mapPivot = (this._map._pivot || new L.Point(0, 0)).clone().add(anchor);
+				L.DomUtil.setPosition(this._container, pos.add(anchor), this._map._bearing || 0, mapPivot);
 			} else {
 				L.DomUtil.setPosition(this._container, pos.add(anchor));
 			}

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -179,7 +179,7 @@ L.DivOverlay = L.Layer.extend({
 
 		if (this._zoomAnimated) {
 			if (this._map._rotate) {
-				pos = this._map.rotatePanePointToNorotatePanePoint(pos);
+				pos = this._map.rotatedPointToMapPanePoint(pos);
 			}
 			L.DomUtil.setPosition(this._container, pos.add(anchor));
 		} else {

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -179,7 +179,7 @@ L.DivOverlay = L.Layer.extend({
 
 		if (this._zoomAnimated) {
 			if (this._map._rotate) {
-				pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
+				pos = this._map.rotatePanePointToNorotatePanePoint(pos);
 			}
 			L.DomUtil.setPosition(this._container, pos.add(anchor));
 		} else {

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -179,7 +179,6 @@ L.DivOverlay = L.Layer.extend({
 
 		if (this._zoomAnimated) {
 			if (this._map._rotate) {
-				// rotation relative to the marker's anchor
 				pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
 			}
 			L.DomUtil.setPosition(this._container, pos.add(anchor));

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -177,17 +177,13 @@ L.DivOverlay = L.Layer.extend({
 		    offset = L.point(this.options.offset),
 		    anchor = this._getAnchor();
 
-		var bottom = this._containerBottom = -offset.y,
-		    left = this._containerLeft = -Math.round(this._containerWidth / 2) + offset.x;
-
 		if (this._zoomAnimated) {
 			if (this._map._rotate) {
 				// rotation relative to the marker's anchor
-				var mapPivot = (this._map._pivot || new L.Point(0, 0)).clone().add(anchor);
-				L.DomUtil.setPosition(this._container, pos.add(anchor), this._map._bearing || 0, mapPivot);
-			} else {
-				L.DomUtil.setPosition(this._container, pos.add(anchor));
+				pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
 			}
+
+			L.DomUtil.setPosition(this._container, pos.add(anchor));
 		} else {
 			offset = offset.add(pos).add(anchor);
 		}

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -182,7 +182,6 @@ L.DivOverlay = L.Layer.extend({
 				// rotation relative to the marker's anchor
 				pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
 			}
-
 			L.DomUtil.setPosition(this._container, pos.add(anchor));
 		} else {
 			offset = offset.add(pos).add(anchor);

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -215,7 +215,7 @@ L.Popup = L.DivOverlay.extend({
 		var pos = this._map._latLngToNewLayerPoint(this._latlng, e.zoom, e.center),
 			anchor = this._getAnchor();
 		if (this._map._rotate) {
-			pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
+			pos = this._map.rotatePanePointToNorotatePanePoint(pos);
 		}
 		L.DomUtil.setPosition(this._container, pos.add(anchor));
 	},

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -227,12 +227,10 @@ L.Popup = L.DivOverlay.extend({
 		    marginBottom = parseInt(L.DomUtil.getStyle(this._container, 'marginBottom'), 10) || 0,
 		    containerHeight = this._container.offsetHeight + marginBottom,
 		    containerWidth = this._containerWidth,
-		    layerPos = new L.Point(this._containerLeft, -containerHeight - this._containerBottom);
+		    offset = new L.Point(this._containerLeft, -containerHeight - this._containerBottom);
 
-		layerPos._add(L.DomUtil.getPosition(this._container));
-
-		var containerPos = map.layerPointToContainerPoint(layerPos),
-		    padding = L.point(this.options.autoPanPadding),
+		var containerPos = L.DomUtil.getPosition(this._container)._add(this._map._getMapPanePos())._add(offset),
+		    padding   = L.point(this.options.autoPanPadding),
 		    paddingTL = L.point(this.options.autoPanPaddingTopLeft || padding),
 		    paddingBR = L.point(this.options.autoPanPaddingBottomRight || padding),
 		    size = map.getSize(),

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -215,7 +215,7 @@ L.Popup = L.DivOverlay.extend({
 		var pos = this._map._latLngToNewLayerPoint(this._latlng, e.zoom, e.center),
 			anchor = this._getAnchor();
 		if (this._map._rotate) {
-			pos = this._map.rotatePanePointToNorotatePanePoint(pos);
+			pos = this._map.rotatedPointToMapPanePoint(pos);
 		}
 		L.DomUtil.setPosition(this._container, pos.add(anchor));
 	},

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -227,10 +227,12 @@ L.Popup = L.DivOverlay.extend({
 		    marginBottom = parseInt(L.DomUtil.getStyle(this._container, 'marginBottom'), 10) || 0,
 		    containerHeight = this._container.offsetHeight + marginBottom,
 		    containerWidth = this._containerWidth,
-		    offset = new L.Point(this._containerLeft, -containerHeight - this._containerBottom);
+		    layerPos = new L.Point(this._containerLeft, -containerHeight - this._containerBottom);
 
-		var containerPos = L.DomUtil.getPosition(this._container)._add(this._map._getMapPanePos())._add(offset),
-		    padding   = L.point(this.options.autoPanPadding),
+		layerPos._add(L.DomUtil.getPosition(this._container));
+
+		var containerPos = layerPos._add(this._map._getMapPanePos()),
+		    padding = L.point(this.options.autoPanPadding),
 		    paddingTL = L.point(this.options.autoPanPaddingTopLeft || padding),
 		    paddingBR = L.point(this.options.autoPanPaddingBottomRight || padding),
 		    size = map.getSize(),

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -215,12 +215,9 @@ L.Popup = L.DivOverlay.extend({
 		var pos = this._map._latLngToNewLayerPoint(this._latlng, e.zoom, e.center),
 			anchor = this._getAnchor();
 		if (this._map._rotate) {
-			var offset = L.point(this.options.offset);
-			var popupAnchor = pos.add([-this._containerLeft, this._container.offsetHeight + this._tipContainer.offsetHeight - offset.y]);
-			L.DomUtil.setPosition(this._container, pos.add(anchor), -this._map._bearing || 0, popupAnchor);
-		} else {
-			L.DomUtil.setPosition(this._container, pos.add(anchor));
+			pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
 		}
+		L.DomUtil.setPosition(this._container, pos.add(anchor));
 	},
 
 	_adjustPan: function () {

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -169,6 +169,9 @@ L.Tooltip = L.DivOverlay.extend({
 
 	_animateZoom: function (e) {
 		var pos = this._map._latLngToNewLayerPoint(this._latlng, e.zoom, e.center);
+		if (this._map._rotate) {
+			pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
+		}
 		this._setPosition(pos);
 	},
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -156,6 +156,9 @@ L.Tooltip = L.DivOverlay.extend({
 
 	_updatePosition: function () {
 		var pos = this._map.latLngToLayerPoint(this._latlng);
+		if (this._map._rotate) {
+			pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
+		}
 		this._setPosition(pos);
 	},
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -157,7 +157,7 @@ L.Tooltip = L.DivOverlay.extend({
 	_updatePosition: function () {
 		var pos = this._map.latLngToLayerPoint(this._latlng);
 		if (this._map._rotate) {
-			pos = this._map.rotatePanePointToNorotatePanePoint(pos);
+			pos = this._map.rotatedPointToMapPanePoint(pos);
 		}
 		this._setPosition(pos);
 	},
@@ -173,7 +173,7 @@ L.Tooltip = L.DivOverlay.extend({
 	_animateZoom: function (e) {
 		var pos = this._map._latLngToNewLayerPoint(this._latlng, e.zoom, e.center);
 		if (this._map._rotate) {
-			pos = this._map.rotatePanePointToNorotatePanePoint(pos);
+			pos = this._map.rotatedPointToMapPanePoint(pos);
 		}
 		this._setPosition(pos);
 	},

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -157,7 +157,7 @@ L.Tooltip = L.DivOverlay.extend({
 	_updatePosition: function () {
 		var pos = this._map.latLngToLayerPoint(this._latlng);
 		if (this._map._rotate) {
-			pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
+			pos = this._map.rotatePanePointToNorotatePanePoint(pos);
 		}
 		this._setPosition(pos);
 	},
@@ -173,7 +173,7 @@ L.Tooltip = L.DivOverlay.extend({
 	_animateZoom: function (e) {
 		var pos = this._map._latLngToNewLayerPoint(this._latlng, e.zoom, e.center);
 		if (this._map._rotate) {
-			pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
+			pos = this._map.rotatePanePointToNorotatePanePoint(pos);
 		}
 		this._setPosition(pos);
 	},

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -67,30 +67,25 @@ L.Handler.MarkerDrag = L.Handler.extend({
 		    .fire('movestart')
 		    .fire('dragstart');
 		if (this._marker._map._rotate){
-			this._draggable.updateMapBearing(this._marker._map._bearing);	
+			this._draggable.updateMapBearing(this._marker._map._bearing);
 		}
 	},
 
 	_onDrag: function (e) {
 		var marker = this._marker,
 		    shadow = marker._shadow,
-		    iconPos = L.DomUtil.getPosition(marker._icon),
-		    latlng = marker._map.layerPointToLatLng(iconPos);
-
-		if (marker._map._rotate) {
-			var iconAnchor = marker.options.icon.options.iconAnchor;
-			L.DomUtil.setPosition(marker._icon, iconPos, -marker._map._bearing, iconPos.add(iconAnchor));
-		}
+		    iconPos = L.DomUtil.getPosition(marker._icon);
 
 		// update shadow position
 		if (shadow) {
-			if (marker._map._rotate) {
-				var shadowAnchor = marker.options.icon.options.shadowAnchor ? iconPos.add(marker.options.icon.options.shadowAnchor) : iconPos.add(iconAnchor);
-				L.DomUtil.setPosition(shadow, iconPos, -marker._map._bearing || 0, shadowAnchor);
-			} else {
-				L.DomUtil.setPosition(shadow, iconPos);
-			}
+			L.DomUtil.setPosition(shadow, iconPos);
 		}
+
+		if (marker._map._rotate) {
+			// Reverse calculation from mapPane coordinates to rotatePane coordinates
+			iconPos = iconPos._subtract(marker._map._getRotatePanePos()).rotate(-marker._map._bearing);
+		}
+		latlng = marker._map.layerPointToLatLng(iconPos);
 
 		marker._latlng = latlng;
 		e.latlng = latlng;
@@ -106,6 +101,8 @@ L.Handler.MarkerDrag = L.Handler.extend({
 	_onDragEnd: function (e) {
 		// @event dragend: DragEndEvent
 		// Fired when the user stops dragging the marker.
+
+		this._marker.update();
 
 		// @event moveend: Event
 		// Fired when the marker stops moving (because of dragging).

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -83,7 +83,7 @@ L.Handler.MarkerDrag = L.Handler.extend({
 
 		if (marker._map._rotate) {
 			// Reverse calculation from mapPane coordinates to rotatePane coordinates
-			iconPos = iconPos._subtract(marker._map._getRotatePanePos()).rotate(-marker._map._bearing);
+			iconPos = marker._map.norotatePanePointToRotatePanePoint(iconPos);
 		}
 		latlng = marker._map.layerPointToLatLng(iconPos);
 

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -83,7 +83,7 @@ L.Handler.MarkerDrag = L.Handler.extend({
 
 		if (marker._map._rotate) {
 			// Reverse calculation from mapPane coordinates to rotatePane coordinates
-			iconPos = marker._map.norotatePanePointToRotatePanePoint(iconPos);
+			iconPos = marker._map.mapPanePointToRotatedPoint(iconPos);
 		}
 		latlng = marker._map.layerPointToLatLng(iconPos);
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -254,9 +254,10 @@ L.Marker = L.Layer.extend({
 	},
 
 	_setPos: function (pos) {
-		var iconAnchor = this.options.icon.options.iconAnchor || new L.Point(0, 0);
+		// var iconAnchor = this.options.icon.options.iconAnchor || new L.Point(0, 0);
+		var mapPivot   = this._map._pivot || new L.Point(0, 0);
 		if (this._map._rotate && this.options.markerRotate) {
-			L.DomUtil.setPosition(this._icon, pos, -this._map._bearing || 0, pos.add(iconAnchor));
+			L.DomUtil.setPosition(this._icon, pos, this._map._bearing || 0, mapPivot);
 		} else {
 			L.DomUtil.setPosition(this._icon, pos);
 		}
@@ -265,9 +266,9 @@ L.Marker = L.Layer.extend({
 		if (this._shadow) {
 			if (this._map._rotate && this.options.markerRotate) {
 				if (this.options.icon.options.shadowAnchor){
-					L.DomUtil.setPosition(this._shadow, pos, -this._map._bearing || 0, pos.add(this.options.icon.options.shadowAnchor));
+					L.DomUtil.setPosition(this._shadow, pos, this._map._bearing || 0, mapPivot);
 				} else {
-					L.DomUtil.setPosition(this._shadow, pos, -this._map._bearing || 0, pos.add(iconAnchor));
+					L.DomUtil.setPosition(this._shadow, pos, this._map._bearing || 0, mapPivot);
 				}
 			} else {
 				L.DomUtil.setPosition(this._shadow, pos);

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -61,10 +61,6 @@ L.Marker = L.Layer.extend({
 
 		// FIXME: shadowPane is no longer a valid option
 		nonBubblingEvents: ['click', 'dblclick', 'mouseover', 'mouseout', 'contextmenu'],
-
-		// @option markerRotate: Boolean = true
-		// Whether the marker remains upright when rotating the map
-		markerRotate: true
 	},
 
 	/* @section
@@ -255,7 +251,7 @@ L.Marker = L.Layer.extend({
 
 	_setPos: function (pos) {
 
-		if(this.options.markerRotate) {
+		if(this._map._rotate) {
 			pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
 		}
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -252,7 +252,7 @@ L.Marker = L.Layer.extend({
 	_setPos: function (pos) {
 
 		if(this._map._rotate) {
-			pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
+			pos = this._map.rotatePanePointToNorotatePanePoint(pos);
 		}
 
 		L.DomUtil.setPosition(this._icon, pos);

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -271,7 +271,7 @@ L.Marker = L.Layer.extend({
 	},
 
 	_updateZIndex: function (offset) {
-		this._icon.style.zIndex = this._zIndex + offset;
+		this._icon.style.zIndex = Math.round(this._zIndex + offset);
 	},
 
 	_animateZoom: function (opt) {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -252,7 +252,7 @@ L.Marker = L.Layer.extend({
 	_setPos: function (pos) {
 
 		if(this._map._rotate) {
-			pos = this._map.rotatePanePointToNorotatePanePoint(pos);
+			pos = this._map.rotatedPointToMapPanePoint(pos);
 		}
 
 		L.DomUtil.setPosition(this._icon, pos);

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -254,25 +254,15 @@ L.Marker = L.Layer.extend({
 	},
 
 	_setPos: function (pos) {
-		// var iconAnchor = this.options.icon.options.iconAnchor || new L.Point(0, 0);
-		// console.log(this._map);
-		var mapPivot    = this._map._pivot || new L.Point(0, 0);
-		if (this._map._rotate && this.options.markerRotate) {
-			L.DomUtil.setPosition(this._icon, pos, this._map._bearing || 0, mapPivot);
-		} else {
-			L.DomUtil.setPosition(this._icon, pos);
+
+		if(this.options.markerRotate) {
+			pos = pos.rotate(this._map._bearing).add(this._map._getRotatePanePos());
 		}
 
+		L.DomUtil.setPosition(this._icon, pos);
+
 		if (this._shadow) {
-			if (this._map._rotate && this.options.markerRotate) {
-				if (this.options.icon.options.shadowAnchor){
-					L.DomUtil.setPosition(this._shadow, pos, this._map._bearing || 0, mapPivot);
-				} else {
-					L.DomUtil.setPosition(this._shadow, pos, this._map._bearing || 0, mapPivot);
-				}
-			} else {
-				L.DomUtil.setPosition(this._shadow, pos);
-			}
+			L.DomUtil.setPosition(this._shadow, pos);
 		}
 
 		this._zIndex = pos.y + this.options.zIndexOffset;

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -61,7 +61,7 @@ L.Marker = L.Layer.extend({
 
 		// FIXME: shadowPane is no longer a valid option
 		nonBubblingEvents: ['click', 'dblclick', 'mouseover', 'mouseout', 'contextmenu'],
-		
+
 		// @option markerRotate: Boolean = true
 		// Whether the marker remains upright when rotating the map
 		markerRotate: true
@@ -255,13 +255,13 @@ L.Marker = L.Layer.extend({
 
 	_setPos: function (pos) {
 		// var iconAnchor = this.options.icon.options.iconAnchor || new L.Point(0, 0);
-		var mapPivot   = this._map._pivot || new L.Point(0, 0);
+		// console.log(this._map);
+		var mapPivot    = this._map._pivot || new L.Point(0, 0);
 		if (this._map._rotate && this.options.markerRotate) {
 			L.DomUtil.setPosition(this._icon, pos, this._map._bearing || 0, mapPivot);
 		} else {
 			L.DomUtil.setPosition(this._icon, pos);
 		}
-
 
 		if (this._shadow) {
 			if (this._map._rotate && this.options.markerRotate) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -681,7 +681,7 @@ L.Map = L.Evented.extend({
 				.subtract(this._getRotatePanePos());
 		}
 		else {
-		return L.point(point).subtract(this._getMapPanePos());
+			return L.point(point).subtract(this._getMapPanePos());
 		}
 	},
 
@@ -696,7 +696,7 @@ L.Map = L.Evented.extend({
 				.add(this._getMapPanePos());
 		}
 		else {
-		return L.point(point).add(this._getMapPanePos());
+			return L.point(point).add(this._getMapPanePos());
 		}
 	},
 
@@ -821,19 +821,17 @@ L.Map = L.Evented.extend({
 
 		if (this._rotate) {
 			this._rotatePane = this.createPane('rotatePane', this._mapPane);
+			this._norotatePane = this.createPane('norotatePane', this._mapPane);
 
 			// @pane tilePane: HTMLElement = 2
 			// Pane for tile layers
 			this.createPane('tilePane', this._rotatePane);
-			// @pane shadowPane: HTMLElement = 5
-			// Pane for overlay shadows (e.g. marker shadows)
-			this.createPane('overlayPane', this._rotatePane);
-
-
-			this._norotatePane = this.createPane('norotatePane', this._mapPane);
-
 			// @pane overlayPane: HTMLElement = 4
 			// Pane for overlays like polylines and polygons
+			this.createPane('overlayPane', this._rotatePane);
+			
+			// @pane shadowPane: HTMLElement = 5
+			// Pane for overlay shadows (e.g. marker shadows)
 			this.createPane('shadowPane', this._norotatePane);
 			// @pane markerPane: HTMLElement = 6
 			// Pane for marker icons

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -829,36 +829,39 @@ L.Map = L.Evented.extend({
 			// @pane overlayPane: HTMLElement = 4
 			// Pane for overlays like polylines and polygons
 			this.createPane('overlayPane', this._rotatePane);
-			
+
 			// @pane shadowPane: HTMLElement = 5
 			// Pane for overlay shadows (e.g. marker shadows)
 			this.createPane('shadowPane', this._norotatePane);
 			// @pane markerPane: HTMLElement = 6
 			// Pane for marker icons
 			this.createPane('markerPane', this._norotatePane);
-			// @pane popupPane: HTMLElement = 7
+			// @pane tooltipPane: HTMLElement = 650
+			// Pane for tooltips.
+			this.createPane('tooltipPane', this._norotatePane);
+			// @pane popupPane: HTMLElement = 700
 			// Pane for popups.
 			this.createPane('popupPane', this._norotatePane);
 		}
 		else {
 			// @pane tilePane: HTMLElement = 2
 			// Pane for tile layers
-		this.createPane('tilePane');
+			this.createPane('tilePane');
 			// @pane overlayPane: HTMLElement = 4
 			// Pane for overlays like polylines and polygons
-		this.createPane('shadowPane');
+			this.createPane('overlayPane');
 			// @pane shadowPane: HTMLElement = 5
 			// Pane for overlay shadows (e.g. marker shadows)
-		this.createPane('overlayPane');
+			this.createPane('shadowPane');
 			// @pane markerPane: HTMLElement = 6
 			// Pane for marker icons
-		this.createPane('markerPane');
-		// @pane tooltipPane: HTMLElement = 650
-		// Pane for tooltip.
-		this.createPane('tooltipPane');
-		// @pane popupPane: HTMLElement = 700
-		// Pane for `Popup`s.
-		this.createPane('popupPane');
+			this.createPane('markerPane');
+			// @pane tooltipPane: HTMLElement = 650
+			// Pane for tooltips.
+			this.createPane('tooltipPane');
+			// @pane popupPane: HTMLElement = 700
+			// Pane for popups.
+			this.createPane('popupPane');
 		}
 
 		if (!this.options.markerZoomAnimation) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -700,6 +700,14 @@ L.Map = L.Evented.extend({
 		}
 	},
 
+	rotatePanePointToNorotatePanePoint: function (point) {
+		return L.point(point).rotate(this._bearing)._add(this._getRotatePanePos());
+	},
+
+	norotatePanePointToRotatePanePoint: function (point) {
+		return L.point(point)._subtract(this._getRotatePanePos()).rotate(-this._bearing);
+	},
+
 	// @method containerPointToLatLng(point: Point): Point
 	// Given a pixel coordinate relative to the map container, returns
 	// the corresponding geographical coordinate (for the current zoom level).

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -825,18 +825,22 @@ L.Map = L.Evented.extend({
 			// @pane tilePane: HTMLElement = 2
 			// Pane for tile layers
 			this.createPane('tilePane', this._rotatePane);
-			// @pane overlayPane: HTMLElement = 4
-			// Pane for overlays like polylines and polygons
-			this.createPane('shadowPane', this._rotatePane);
 			// @pane shadowPane: HTMLElement = 5
 			// Pane for overlay shadows (e.g. marker shadows)
 			this.createPane('overlayPane', this._rotatePane);
+
+
+			this._norotatePane = this.createPane('norotatePane', this._mapPane);
+
+			// @pane overlayPane: HTMLElement = 4
+			// Pane for overlays like polylines and polygons
+			this.createPane('shadowPane', this._norotatePane);
 			// @pane markerPane: HTMLElement = 6
 			// Pane for marker icons
-			this.createPane('markerPane', this._rotatePane);
+			this.createPane('markerPane', this._norotatePane);
 			// @pane popupPane: HTMLElement = 7
 			// Pane for popups.
-			this.createPane('popupPane', this._rotatePane);
+			this.createPane('popupPane', this._norotatePane);
 		}
 		else {
 			// @pane tilePane: HTMLElement = 2

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -700,11 +700,17 @@ L.Map = L.Evented.extend({
 		}
 	},
 
-	rotatePanePointToNorotatePanePoint: function (point) {
+	// @method rotatedPointToMapPanePoint(point: Point): Point
+	// Converts a coordinate from the rotated pane reference system
+	// to the reference system of the not rotated map pane.
+	rotatedPointToMapPanePoint: function (point) {
 		return L.point(point).rotate(this._bearing)._add(this._getRotatePanePos());
 	},
 
-	norotatePanePointToRotatePanePoint: function (point) {
+	// @method mapPanePointToRotatedPoint(point: Point): Point
+	// Converts a coordinate from the not rotated map pane reference system
+	// to the reference system of the rotated pane.
+	mapPanePointToRotatedPoint: function (point) {
 		return L.point(point)._subtract(this._getRotatePanePos()).rotate(-this._bearing);
 	},
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -741,10 +741,10 @@ L.Map = L.Evented.extend({
 	setBearing: function(theta) {
 		if (!L.Browser.any3d || !this._rotate) { return; }
 
+		var rotatePanePos = this._getRotatePanePos();
 		var halfSize = this.getSize().divideBy(2);
 		this._pivot = this._getMapPanePos().clone().multiplyBy(-1).add(halfSize);
 
-		var rotatePanePos = this._getRotatePanePos();
 		rotatePanePos = rotatePanePos.rotateFrom(-this._bearing, this._pivot);
 
 		this._bearing = theta * L.DomUtil.DEG_TO_RAD; // TODO: mod 360

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -741,16 +741,22 @@ L.Map = L.Evented.extend({
 	setBearing: function(theta) {
 		if (!L.Browser.any3d || !this._rotate) { return; }
 
-		var rotatePanePos = this._getRotatePanePos();
 		var halfSize = this.getSize().divideBy(2);
 		this._pivot = this._getMapPanePos().clone().multiplyBy(-1).add(halfSize);
 
-		rotatePanePos = rotatePanePos.rotateFrom(-this._bearing, this._pivot);
-
+		this._oldBearing = this._bearing;
 		this._bearing = theta * L.DomUtil.DEG_TO_RAD; // TODO: mod 360
-		this._rotatePanePos = rotatePanePos.rotateFrom(this._bearing, this._pivot);
 
-		L.DomUtil.setPosition(this._rotatePane, this._rotatePanePos, this._bearing, this._rotatePanePos);
+		var rotatePanePos = this._getRotatePanePos();
+		rotatePanePos = rotatePanePos.rotateFrom(-this._oldBearing, this._pivot);
+
+		// Because the pivot is the same as the position, this call is only used for setting the transform, not for transforming
+		// L.DomUtil.setPosition(this._rotatePane, this._rotatePanePos, this._bearing, this._rotatePanePos);
+
+		L.DomUtil.setPosition(this._rotatePane, rotatePanePos, this._bearing, this._pivot);
+
+		// TODO Replace with other method (reading out the transform values?)
+		this._rotatePanePos = rotatePanePos.rotateFrom(this._bearing, this._pivot);
 
 		this.fire('rotate');
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -744,19 +744,13 @@ L.Map = L.Evented.extend({
 		var halfSize = this.getSize().divideBy(2);
 		this._pivot = this._getMapPanePos().clone().multiplyBy(-1).add(halfSize);
 
-		this._oldBearing = this._bearing;
-		this._bearing = theta * L.DomUtil.DEG_TO_RAD; // TODO: mod 360
-
 		var rotatePanePos = this._getRotatePanePos();
-		rotatePanePos = rotatePanePos.rotateFrom(-this._oldBearing, this._pivot);
+		rotatePanePos = rotatePanePos.rotateFrom(-this._bearing, this._pivot);
 
-		// Because the pivot is the same as the position, this call is only used for setting the transform, not for transforming
-		// L.DomUtil.setPosition(this._rotatePane, this._rotatePanePos, this._bearing, this._rotatePanePos);
+		this._bearing = theta * L.DomUtil.DEG_TO_RAD; // TODO: mod 360
+		this._rotatePanePos = rotatePanePos.rotateFrom(this._bearing, this._pivot);
 
 		L.DomUtil.setPosition(this._rotatePane, rotatePanePos, this._bearing, this._pivot);
-
-		// TODO Replace with other method (reading out the transform values?)
-		this._rotatePanePos = rotatePanePos.rotateFrom(this._bearing, this._pivot);
 
 		this.fire('rotate');
 	},


### PR DESCRIPTION
In reference to the comment at https://github.com/fnicollet/Leaflet/issues/8#issuecomment-249875366, that the markers, popups and tooltips should not be rotated back and forth, but instead be rotated _zero_ times, I started this branch to try to accomplish that.

I split the map panes in two groups, leaving the tilePane and the overlayPane within the rotatePane, but creating a new norotatePane for the three other panes.

I adapted a bit of the positioning logic, but I am now stuck.

What works:
Panning, zooming, initial rotating

What does not work:
Rotating, then panning, then rotating (or zooming). The origin of the second rotate/zooming action is wrong for the elements in the no-rotate pane. I don't know how to fix it currently and am hoping for the input of experienced Leaflet devs here ;-) I'm guessing I need to reset the origin somewhere, somehow...?

You can try out the changes and problems at
https://rawgit.com/sisou/Leaflet/zero-rotate/debug/rotate/rotate.html
https://rawgit.com/sisou/Leaflet/zero-rotate/debug/rotate/rotate-and-drag.html