### PR TITLE
Fix examples: Update position of the range input when a button is clicked

### DIFF
--- a/debug/rotate/rotate-and-drag.html
+++ b/debug/rotate/rotate-and-drag.html
@@ -20,16 +20,16 @@
 
 	<div id="map"></div>
 
-	<input type="range" min="0" max="360" step="1" name="rho" id='rho_input' style='width:800px'/><span id='rho'></span>
+	<input type="range" min="0" max="360" value="0" step="1" name="rho" id='rho_input' style='width:800px'/><span id='rho'></span>
 
 	<div>
-		<button onclick="map.setBearing(0);" > 0</button>
-		<button onclick="map.setBearing(15);">15</button>
-		<button onclick="map.setBearing(30);">30</button>
-		<button onclick="map.setBearing(45);">45</button>
-		<button onclick="map.setBearing(60);">60</button>
-		<button onclick="map.setBearing(75);">75</button>
-		<button onclick="map.setBearing(90);">90</button>
+		<button onclick="rotateFromButton(0);" > 0</button>
+		<button onclick="rotateFromButton(15);">15</button>
+		<button onclick="rotateFromButton(30);">30</button>
+		<button onclick="rotateFromButton(45);">45</button>
+		<button onclick="rotateFromButton(60);">60</button>
+		<button onclick="rotateFromButton(75);">75</button>
+		<button onclick="rotateFromButton(90);">90</button>
 	</div>
 
 	<script type="text/javascript">
@@ -67,6 +67,11 @@
 			if (ev.buttons === 0) return;
 			var angle = ev.target.valueAsNumber;
 // 			console.log(angle);
+			map.setBearing(angle);
+		}
+
+		function rotateFromButton(angle) {
+			document.getElementById('rho_input').valueAsNumber = angle;
 			map.setBearing(angle);
 		}
 

--- a/debug/rotate/rotate.html
+++ b/debug/rotate/rotate.html
@@ -101,16 +101,16 @@
 			<td class='long'>Negative pixel coords of the (0,0) CRS point relative to _rotatePane</td></tr>
 	</table>
 
-	<input type="range" min="0" max="360" step="1" name="rho" id='rho_input' /><span id='rho'></span>
+	<input type="range" min="0" max="360" value="0" step="1" name="rho" id='rho_input' /><span id='rho'></span>
 
 	<div>
-		<button onclick="map.setBearing(0);" > 0</button>
-		<button onclick="map.setBearing(15);">15</button>
-		<button onclick="map.setBearing(30);">30</button>
-		<button onclick="map.setBearing(45);">45</button>
-		<button onclick="map.setBearing(60);">60</button>
-		<button onclick="map.setBearing(75);">75</button>
-		<button onclick="map.setBearing(90);">90</button>
+		<button onclick="rotateFromButton(0);" > 0</button>
+		<button onclick="rotateFromButton(15);">15</button>
+		<button onclick="rotateFromButton(30);">30</button>
+		<button onclick="rotateFromButton(45);">45</button>
+		<button onclick="rotateFromButton(60);">60</button>
+		<button onclick="rotateFromButton(75);">75</button>
+		<button onclick="rotateFromButton(90);">90</button>
 	</div>
 
 	<div>
@@ -180,6 +180,10 @@
 			map.setBearing(angle);
 		}
 
+		function rotateFromButton(angle) {
+			document.getElementById('rho_input').valueAsNumber = angle;
+			map.setBearing(angle);
+		}
 
 		map.on('move rotate zoomend', function(ev) {
 			var panePos = this._getMapPanePos();


### PR DESCRIPTION
This PR improves the rotate examples that have a slider.

I noticed that the slider does not move when the bearing is set via a button, and that the slider is in the center (180deg) position on page load. Both of these things make the map rotation jump when touching the slider after page load or after setting the bearing with a button.

This fixes that.