### PR TITLE
Start on fixing map bounds when rotating

### DIFF
--- a/debug/rotate/rotate-bounds.html
+++ b/debug/rotate/rotate-bounds.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+
+	<style>
+	</style>
+</head>
+<body>
+
+
+	<div id="map"></div>
+
+	<input type="range" min="0" max="360" value="0" step="1" name="rho" id='rho_input' style='width:800px'/><span id='rho'></span>
+
+	<div>
+		<button onclick="rotateFromButton(0);" > 0</button>
+		<button onclick="rotateFromButton(15);">15</button>
+		<button onclick="rotateFromButton(30);">30</button>
+		<button onclick="rotateFromButton(45);">45</button>
+		<button onclick="rotateFromButton(60);">60</button>
+		<button onclick="rotateFromButton(75);">75</button>
+		<button onclick="rotateFromButton(90);">90</button>
+	</div>
+
+	<script type="text/javascript">
+
+		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+		var map = L.map('map', {rotate: true})
+				.setView([55, 10], 0)
+				.addLayer(osm);
+
+		function rotate(ev) {
+			if (ev.buttons === 0) return;
+			var angle = ev.target.valueAsNumber;
+// 			console.log(angle);
+			map.setBearing(angle);
+		}
+
+		function rotateFromButton(angle) {
+			document.getElementById('rho_input').valueAsNumber = angle;
+			map.setBearing(angle);
+		}
+
+		document.getElementById('rho_input').addEventListener('change', rotate);
+		document.getElementById('rho_input').addEventListener('mousemove', rotate);
+
+		var centerMarker;
+		var bounds;
+		function displayCenter() {
+			if (centerMarker) { centerMarker.remove(); }
+			centerMarker = L.circleMarker(map.getCenter()).addTo(map);
+
+			if (bounds) { bounds.remove(); }
+			bounds = L.rectangle(map.getBounds()).addTo(map);
+		}
+
+		map.on('moveend zoomend resetview rotate', displayCenter);
+
+		displayCenter();
+
+	</script>
+</body>
+</html>

--- a/debug/rotate/rotate-bounds.html
+++ b/debug/rotate/rotate-bounds.html
@@ -20,6 +20,7 @@
 
 	<div id="map"></div>
 
+	Rotation:<br>
 	<input type="range" min="0" max="360" value="0" step="1" name="rho" id='rho_input' style='width:800px'/><span id='rho'></span>
 
 	<div>
@@ -31,6 +32,9 @@
 		<button onclick="rotateFromButton(75);">75</button>
 		<button onclick="rotateFromButton(90);">90</button>
 	</div>
+	<br>
+	Padding:<br>
+	<input type="range" min="-0.25" max="0" value="-0.05" step="0.01" name="pad" id='pad_input' style='width:800px' onchange="displayCenter()" onmousemove="displayCenter()"/>
 
 	<script type="text/javascript">
 
@@ -39,7 +43,7 @@
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 
 		var map = L.map('map', {rotate: true})
-				.setView([55, 10], 0)
+				.setView([0, 0], 4)
 				.addLayer(osm);
 
 		function rotate(ev) {
@@ -64,7 +68,8 @@
 			centerMarker = L.circleMarker(map.getCenter()).addTo(map);
 
 			if (bounds) { bounds.remove(); }
-			bounds = L.rectangle(map.getBounds()).addTo(map);
+			var padding = document.getElementById('pad_input').valueAsNumber;
+			bounds = L.rectangle(map.getBounds().pad(padding)).addTo(map);
 		}
 
 		map.on('moveend zoomend resetview rotate', displayCenter);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -486,9 +486,13 @@ L.Map = L.Evented.extend({
 	// @method getBounds(): LatLngBounds
 	// Returns the geographical bounds visible in the current map view
 	getBounds: function () {
-		var bounds = this.getPixelBounds(),
-		    sw = this.unproject(bounds.getBottomLeft()),
-		    ne = this.unproject(bounds.getTopRight());
+		// var bounds = this.getPixelBounds(),
+		//     sw = this.unproject(bounds.getBottomLeft()),
+		//     ne = this.unproject(bounds.getTopRight());
+
+		var size = this.getSize();
+		var sw = this.layerPointToLatLng(this.containerPointToLayerPoint([0, size.y]));
+		var ne = this.layerPointToLatLng(this.containerPointToLayerPoint([size.x, 0]));
 
 		return new L.LatLngBounds(sw, ne);
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -486,15 +486,14 @@ L.Map = L.Evented.extend({
 	// @method getBounds(): LatLngBounds
 	// Returns the geographical bounds visible in the current map view
 	getBounds: function () {
-		// var bounds = this.getPixelBounds(),
-		//     sw = this.unproject(bounds.getBottomLeft()),
-		//     ne = this.unproject(bounds.getTopRight());
-
 		var size = this.getSize();
-		var sw = this.layerPointToLatLng(this.containerPointToLayerPoint([0, size.y]));
-		var ne = this.layerPointToLatLng(this.containerPointToLayerPoint([size.x, 0]));
+		var topleft     = this.layerPointToLatLng(this.containerPointToLayerPoint([0, 0])),
+			topright    = this.layerPointToLatLng(this.containerPointToLayerPoint([size.x, 0])),
+			bottomright = this.layerPointToLatLng(this.containerPointToLayerPoint([size.x, size.y])),
+			bottomleft  = this.layerPointToLatLng(this.containerPointToLayerPoint([0, size.y]));
 
-		return new L.LatLngBounds(sw, ne);
+		// Use LatLngBounds' build-in constructor that automatically extends the bounds to fit the passed points
+		return new L.LatLngBounds([topleft, topright, bottomright, bottomleft]);
 	},
 
 	// @method getMinZoom(): Number

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -488,9 +488,9 @@ L.Map = L.Evented.extend({
 	getBounds: function () {
 		var size = this.getSize();
 		var topleft     = this.layerPointToLatLng(this.containerPointToLayerPoint([0, 0])),
-			topright    = this.layerPointToLatLng(this.containerPointToLayerPoint([size.x, 0])),
-			bottomright = this.layerPointToLatLng(this.containerPointToLayerPoint([size.x, size.y])),
-			bottomleft  = this.layerPointToLatLng(this.containerPointToLayerPoint([0, size.y]));
+		    topright    = this.layerPointToLatLng(this.containerPointToLayerPoint([size.x, 0])),
+		    bottomright = this.layerPointToLatLng(this.containerPointToLayerPoint([size.x, size.y])),
+		    bottomleft  = this.layerPointToLatLng(this.containerPointToLayerPoint([0, size.y]));
 
 		// Use LatLngBounds' build-in constructor that automatically extends the bounds to fit the passed points
 		return new L.LatLngBounds([topleft, topright, bottomright, bottomleft]);


### PR DESCRIPTION
This PR starts work on the issue, highlighted in #7, that the map bounds are returned incorrectly when the map is rotated.

There is however an issue with bounds expressed as a single LatLng pair, when the map is rotated, as the visible-map borders are no longer going along latitude or longitude values, but go diagonal.

I added a new debug demo page ("rotate-bounds.html") to visualise the problem:
https://rawgit.com/sisou/Leaflet/bugfix/7-fix-getbounds-when-rotated/debug/rotate/rotate-bounds.html

As you my know, the bounding box is defined by its NE and SW corner. But in my page (which is not necessarily doing it correctly) the NE and SW are not in fact those cardinal directions, but simply the lower left and top right corners of the visible map.

The general question is now: How should map bounds be represented in a rotated map, where it is not enough to only know the SW and NE corners?