### PR TITLE
Add rotation support for Markers

### DIFF
--- a/debug/rotate/rotated-marker.html
+++ b/debug/rotate/rotated-marker.html
@@ -120,7 +120,8 @@
 	</div>
 
 	<div>
-		<button onclick="randomRotateMarkers();">shake it</button>
+		<button onclick="randomRotateMarkers();">Rotate markers randomly</button>
+		Note: 2 markers on USA don't rotateWithView
 	</div>
 
 
@@ -151,31 +152,31 @@
 				.addLayer(osm)
 				.addLayer(path);
 
-		var marker1 = L.marker(kyiv	, { rotation: 0  , rotateWithView: true }).addTo(map),
-			marker2 = L.marker(lnd	, { rotation: 0.3, rotateWithView: true }).addTo(map),
-			marker3 = L.marker(dc	, { rotation: 0.9, rotateWithView: true }).addTo(map),
-			marker4 = L.marker(sf	, { rotation: 1.5, rotateWithView: true }).addTo(map),
-			marker5 = L.marker(trd	, { rotation: 2.4, rotateWithView: true }).addTo(map);
+		var marker1 = L.marker(kyiv	, { rotation: 0  , rotateWithView: true  }).addTo(map),
+			marker2 = L.marker(lnd	, { rotation: 0.3, rotateWithView: true  }).addTo(map),
+			marker3 = L.marker(dc	, { rotation: 0.9, rotateWithView: false }).addTo(map),
+			marker4 = L.marker(sf	, { rotation: 1.5, rotateWithView: false }).addTo(map),
+			marker5 = L.marker(trd	, { rotation: 2.4, rotateWithView: true  }).addTo(map);
 
 		var loremIpsum = "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit, posuere a, pede.</p><p>Donec nec justo eget felis facilisis fermentum. Aliquam porttitor mauris sit amet orci. Aenean dignissim pellentesque.</p>";
 
 		marker1.bindPopup(loremIpsum + '<p>Kyiv</p>').addTo(map);
 		marker2.bindPopup(loremIpsum + '<p>Lnd</p>').addTo(map);
-		marker3.bindPopup(loremIpsum + '<p>DC</p>').addTo(map);
-		marker4.bindPopup(loremIpsum + '<p>DF</p>').addTo(map);
+		marker3.bindPopup(loremIpsum + '<p>DC doesn\'t rotate with map.</p>').addTo(map);
+		marker4.bindPopup(loremIpsum + '<p>DF doesn\'t rotate with map.</p>').addTo(map);
 		marker5.bindPopup(loremIpsum + '<p>Trd</p>').addTo(map);
 
 		function randomRotateMarkers() {
-			function getDelta() { return Math.random() * Math.PI / 30 }
+			function getDelta() { return Math.random() * Math.PI / 30 + 0.1 }
 			function stepOn() {
 				for (var i = 0; i < markers.length; i++) {
 					markers[i].setRotation(markers[i].options.rotation + steps[i]);
 				}
-				if (--steps_left) setTimeout(stepOn, 50);
+				if (--steps_left) setTimeout(stepOn, 20);
 			}
 			var markers = [marker1, marker2, marker3, marker4, marker5];
 			var steps = [getDelta(), getDelta(), getDelta(), getDelta(), getDelta()];
-			var steps_left = 10;
+			var steps_left = 25;
 			stepOn();
 		}
 

--- a/debug/rotate/rotated-marker.html
+++ b/debug/rotate/rotated-marker.html
@@ -152,11 +152,11 @@
 				.addLayer(osm)
 				.addLayer(path);
 
-		var marker1 = L.marker(kyiv	, { rotation: 0  , rotateWithView: true  }).addTo(map),
-			marker2 = L.marker(lnd	, { rotation: 0.3, rotateWithView: true  }).addTo(map),
-			marker3 = L.marker(dc	, { rotation: 0.9, rotateWithView: false }).addTo(map),
-			marker4 = L.marker(sf	, { rotation: 1.5, rotateWithView: false }).addTo(map),
-			marker5 = L.marker(trd	, { rotation: 2.4, rotateWithView: true  }).addTo(map);
+		var marker1 = L.marker(kyiv	, { rotation: 0  , draggable: true, rotateWithView: true  }).addTo(map),
+			marker2 = L.marker(lnd	, { rotation: 0.3, draggable: true, rotateWithView: true  }).addTo(map),
+			marker3 = L.marker(dc	, { rotation: 0.9, draggable: true, rotateWithView: false }).addTo(map),
+			marker4 = L.marker(sf	, { rotation: 1.5, draggable: true, rotateWithView: false }).addTo(map),
+			marker5 = L.marker(trd	, { rotation: 2.4, draggable: true, rotateWithView: true  }).addTo(map);
 
 		var loremIpsum = "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit, posuere a, pede.</p><p>Donec nec justo eget felis facilisis fermentum. Aliquam porttitor mauris sit amet orci. Aenean dignissim pellentesque.</p>";
 

--- a/debug/rotate/rotated-marker.html
+++ b/debug/rotate/rotated-marker.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+	<script src="../vector/route.js"></script>
+
+	<style>
+	td {
+		width: 7em;
+		overflow: hidden;
+		max-width: 7em;
+		text-overflow: ellipsis;
+	}
+	th {
+		text-align: left;
+	}
+	td.long {
+		width: calc(90vw - 21em);
+		max-width: calc(90vw - 21em);
+	}
+	div.crosshair {
+		position:absolute;
+		width:1px;
+		height:1px;
+		border: 1px dotted green;
+		z-index: 100;
+	}
+	div.pivot {
+		position:absolute;
+		width:1px;
+		height:1px;
+		border: 1px solid purple;
+		z-index: 100;
+	}
+	div.pixelorigin {
+		position:absolute;
+		width:1px;
+		height:1px;
+		border: 1px solid cyan;
+		z-index: 100;
+	}
+	div.panebounds.main {
+		position:absolute;
+		width:800px;
+		height:600px;
+		border: 1px solid red;
+		border-bottom: 1px red dashed;
+		border-right: 1px red dashed;
+		z-index: 100;
+	}
+	div.panebounds.rotate {
+		position:absolute;
+		width:800px;
+		height:600px;
+		border: 1px solid purple;
+		border-bottom: 1px purple dashed;
+		border-right: 1px purple dashed;
+		z-index: 100;
+	}
+	div.crosshair.c1 {
+		left:399px;
+		top:299px;
+	}
+	div.crosshair.c2 {
+		left:499px;
+		top:399px;
+	}
+	</style>
+</head>
+<body>
+
+
+	<div id="map">
+		<div class="crosshair c1"></div>
+<!-- 		<div class="crosshair c2"></div> -->
+	</div>
+
+
+
+	<table>
+		<tr><th>LatLng          </th><td id='llx'></td><td id='lly'></td>
+			<td class='long'>LatLng of mouse pointer</td></tr>
+		<tr><th>Rel to pane     </th><td id='lyx'></td><td id='lyy'></td>
+			<td class='long'>Mouse pointer pixel coords relative to _rotatePane</td></tr>
+		<tr><th>Rel to container</th><td id='cnx'></td><td id='cny'></td>
+			<td class='long'>Mouse pointer coords relative to map &lt;div&gt;</td></tr>
+		<tr><th>Pivot           </th><td id='pvx'></td><td id='pvy'></td>
+			<td class='long'>Last _rotationPane pivot pixel coords relative to _rotationPane</td></tr>
+		<tr><th>Pane offset     </th><td id='pox'></td><td id='poy'></td>
+			<td class='long'>Pixel offset of _mapPane</td></tr>
+		<tr><th>Pixel origin    </th><td id='ogx'></td><td id='ogy'></td>
+			<td class='long'>Negative pixel coords of the (0,0) CRS point relative to _rotatePane</td></tr>
+	</table>
+
+	<input type="range" min="0" max="360" value="0" step="1" name="rho" id='rho_input' /><span id='rho'></span>
+
+	<div>
+		<button onclick="rotateFromButton(0);" > 0</button>
+		<button onclick="rotateFromButton(15);">15</button>
+		<button onclick="rotateFromButton(30);">30</button>
+		<button onclick="rotateFromButton(45);">45</button>
+		<button onclick="rotateFromButton(60);">60</button>
+		<button onclick="rotateFromButton(75);">75</button>
+		<button onclick="rotateFromButton(90);">90</button>
+	</div>
+
+	<div>
+		<button onclick="map.flyTo(trd, 10);" >flyTo TRD</button>
+		<button onclick="map.flyTo(kyiv, 10);">flyTo Kiev</button>
+		<button onclick="map.flyTo(sf, 10);">flyTo SF</button>
+	</div>
+
+	<div>
+		<button onclick="randomRotateMarkers();">shake it</button>
+	</div>
+
+
+	<script type="text/javascript">
+
+		var kyiv = [50.5, 30.5],
+			lnd = [51.51, -0.12],
+			sf = [37.77, -122.42],
+			dc = [38.91, -77.04],
+			trd = [63.41, 10.41];
+
+
+		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+
+		for (var i = 0, latlngs = [], len = route.length; i < len; i++) {
+			latlngs.push(new L.LatLng(route[i][0], route[i][1]));
+		}
+		var path = new L.Polyline(latlngs, {
+			renderer: L.canvas()
+		});
+
+
+		var map = L.map('map', {rotate: true})
+				.setView([55, 10], 0)
+				.addLayer(osm)
+				.addLayer(path);
+
+		var marker1 = L.marker(kyiv	, { rotation: 0  , rotateWithView: true }).addTo(map),
+			marker2 = L.marker(lnd	, { rotation: 0.3, rotateWithView: true }).addTo(map),
+			marker3 = L.marker(dc	, { rotation: 0.9, rotateWithView: true }).addTo(map),
+			marker4 = L.marker(sf	, { rotation: 1.5, rotateWithView: true }).addTo(map),
+			marker5 = L.marker(trd	, { rotation: 2.4, rotateWithView: true }).addTo(map);
+
+		var loremIpsum = "<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit, posuere a, pede.</p><p>Donec nec justo eget felis facilisis fermentum. Aliquam porttitor mauris sit amet orci. Aenean dignissim pellentesque.</p>";
+
+		marker1.bindPopup(loremIpsum + '<p>Kyiv</p>').addTo(map);
+		marker2.bindPopup(loremIpsum + '<p>Lnd</p>').addTo(map);
+		marker3.bindPopup(loremIpsum + '<p>DC</p>').addTo(map);
+		marker4.bindPopup(loremIpsum + '<p>DF</p>').addTo(map);
+		marker5.bindPopup(loremIpsum + '<p>Trd</p>').addTo(map);
+
+		function randomRotateMarkers() {
+			function getDelta() { return Math.random() * Math.PI / 30 }
+			function stepOn() {
+				for (var i = 0; i < markers.length; i++) {
+					markers[i].setRotation(markers[i].options.rotation + steps[i]);
+				}
+				if (--steps_left) setTimeout(stepOn, 50);
+			}
+			var markers = [marker1, marker2, marker3, marker4, marker5];
+			var steps = [getDelta(), getDelta(), getDelta(), getDelta(), getDelta()];
+			var steps_left = 10;
+			stepOn();
+		}
+
+
+		function logEvent(e) { console.log(e, e.type); }
+
+		function logMouse(ev) {
+			document.getElementById('llx').innerHTML = ev.latlng.lng;
+			document.getElementById('lly').innerHTML = ev.latlng.lat;
+			document.getElementById('lyx').innerHTML = ev.layerPoint.x;
+			document.getElementById('lyy').innerHTML = ev.layerPoint.y;
+			document.getElementById('cnx').innerHTML = ev.containerPoint.x;
+			document.getElementById('cny').innerHTML = ev.containerPoint.y;
+		}
+
+		function rotate(ev) {
+			if (ev.buttons === 0) return;
+			var angle = ev.target.valueAsNumber;
+// 			console.log(angle);
+			map.setBearing(angle);
+		}
+
+		function rotateFromButton(angle) {
+			document.getElementById('rho_input').valueAsNumber = angle;
+			map.setBearing(angle);
+		}
+
+		map.on('move rotate zoomend', function(ev) {
+			var panePos = this._getMapPanePos();
+			document.getElementById('pox').innerHTML = panePos.x;
+			document.getElementById('poy').innerHTML = panePos.y;
+
+		});
+
+
+		var pixelOrigin = L.DomUtil.create('div', 'pixelorigin', map._rotatePane);
+		function updatePixelOrigin(ev) {
+			document.getElementById('ogx').innerHTML = map._pixelOrigin.x;
+			document.getElementById('ogy').innerHTML = map._pixelOrigin.y;
+			pixelOrigin.style.left = ( - map._pixelOrigin.x -1 ) + 'px';
+			pixelOrigin.style.top  = ( - map._pixelOrigin.y -1 ) + 'px';
+		};
+		map.on('rotate zoomend load', updatePixelOrigin);
+		updatePixelOrigin();
+
+		document.getElementById('rho_input').addEventListener('change', rotate);
+		document.getElementById('rho_input').addEventListener('mousemove', rotate);
+
+
+		function rotateOneDegree() {
+			var angle = document.getElementById('rho_input').valueAsNumber++;
+			if (document.getElementById('rho_input').valueAsNumber >= 360) {
+				document.getElementById('rho_input').valueAsNumber = 0;
+			}
+			map.setBearing(angle);
+		}
+
+
+		var pivotDot = L.DomUtil.create('div', 'pivot', map._mapPane);
+		L.DomUtil.create('div', 'panebounds rotate', map._rotatePane);
+		L.DomUtil.create('div', 'panebounds main', map._mapPane);
+
+		map.on('rotate', function(ev) {
+			document.getElementById('pvx').innerHTML = map._pivot.x;
+			document.getElementById('pvy').innerHTML = map._pivot.y;
+			pivotDot.style.left = ( map._pivot.x -1 ) + 'px';
+			pivotDot.style.top  = ( map._pivot.y -1 ) + 'px';
+		});
+
+
+
+// 		window.setInterval(rotateOneDegree, 500);
+
+
+		map.on('mousemove', logMouse);
+		// map.on('click', logEvent);
+
+		// map.on('movestart', logEvent);
+		// 		map.on('move', logEvent);
+		// map.on('moveend', logEvent);
+
+		// map.on('zoomstart', logEvent);
+		// map.on('zoomend', logEvent);
+
+	</script>
+</body>
+</html>

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -187,7 +187,15 @@ L.Point.prototype = {
 
 	rotateFrom: function(theta, pivot) {
 		if (!theta) { return this; }
-		return this.clone().subtract(pivot).rotate(theta).add(pivot);
+		var sinTheta = Math.sin(theta);
+		var cosTheta = Math.cos(theta);
+		var cx = pivot.x, cy = pivot.y;
+		var x = this.x - cx, y = this.y - cy;
+
+		return new L.Point(
+			x * cosTheta - y * sinTheta + cx,
+			x * sinTheta + y * cosTheta + cy
+		);
 	}
 };
 

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -187,6 +187,11 @@ L.Point.prototype = {
 
 	rotateFrom: function(theta, pivot) {
 		if (!theta) { return this; }
+		// Rotate around (pivot.x, pivot.y) by:
+		// 1. subtract (pivot.x, pivot.y)
+		// 2. rotate around (0, 0)
+		// 3. add (pivot.x, pivot.y) back
+		// same as `this.subtract(pivot).rotate(theta).add(pivot)`
 		var sinTheta = Math.sin(theta);
 		var cosTheta = Math.cos(theta);
 		var cx = pivot.x, cy = pivot.y;

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -117,6 +117,7 @@ L.Icon = L.Class.extend({
 			img.style.marginLeft = (-anchor.x) + 'px';
 			img.style.marginTop  = (-anchor.y) + 'px';
 		}
+		img.style[L.DomUtil.TRANSFORM + "Origin"] = anchor ? (anchor.x + "px " + anchor.y + "px 0px") : "center center 0px";
 
 		if (size) {
 			img.style.width  = size.x + 'px';

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -116,8 +116,8 @@ L.Icon = L.Class.extend({
 		if (anchor) {
 			img.style.marginLeft = (-anchor.x) + 'px';
 			img.style.marginTop  = (-anchor.y) + 'px';
+			img.style[L.DomUtil.TRANSFORM + "Origin"] = anchor.x + "px " + anchor.y + "px 0px";
 		}
-		img.style[L.DomUtil.TRANSFORM + "Origin"] = anchor ? (anchor.x + "px " + anchor.y + "px 0px") : "center center 0px";
 
 		if (size) {
 			img.style.width  = size.x + 'px';

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -73,11 +73,12 @@ L.Handler.MarkerDrag = L.Handler.extend({
 
 	_onDrag: function (e) {
 		var marker = this._marker,
+		    rotated_marker = marker.options.rotation || marker.options.rotateWithView,
 		    shadow = marker._shadow,
 		    iconPos = L.DomUtil.getPosition(marker._icon);
 
 		// update shadow position
-		if (shadow) {
+		if (!rotated_marker && shadow) {
 			L.DomUtil.setPosition(shadow, iconPos);
 		}
 
@@ -91,10 +92,12 @@ L.Handler.MarkerDrag = L.Handler.extend({
 		e.latlng = latlng;
 		e.oldLatLng = this._oldLatLng;
 
+		if (rotated_marker) marker.setLatLng(latlng); // use `setLatLng` to presisit rotation. low efficiency
+		else marker.fire('move', e); // `setLatLng` will trig 'move' event. we imitate here.
+
 		// @event drag: Event
 		// Fired repeatedly while the user drags the marker.
 		marker
-		    .fire('move', e)
 		    .fire('drag', e);
 	},
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -59,6 +59,14 @@ L.Marker = L.Layer.extend({
 		// `Map pane` where the markers icon will be added.
 		pane: 'markerPane',
 
+		// @option rotation: Number = 0
+		// Rotation of this marker in rad
+		rotation: 0,
+
+		// @option rotateWithView: Boolean = false
+		// Rotate this marker when map rotates
+		rotateWithView: false,
+
 		// FIXME: shadowPane is no longer a valid option
 		nonBubblingEvents: ['click', 'dblclick', 'mouseover', 'mouseout', 'contextmenu'],
 	},
@@ -255,10 +263,15 @@ L.Marker = L.Layer.extend({
 			pos = this._map.rotatedPointToMapPanePoint(pos);
 		}
 
-		L.DomUtil.setPosition(this._icon, pos);
+		var bearing = this.options.rotation || 0;
+		if (this.options.rotateWithView) {
+			bearing += this._map._bearing;
+		}
+
+		L.DomUtil.setPosition(this._icon, pos, bearing, pos);
 
 		if (this._shadow) {
-			L.DomUtil.setPosition(this._shadow, pos);
+			L.DomUtil.setPosition(this._shadow, pos, bearing, pos);
 		}
 
 		this._zIndex = pos.y + this.options.zIndexOffset;
@@ -308,6 +321,11 @@ L.Marker = L.Layer.extend({
 		}
 
 		return this;
+	},
+
+	setRotation: function (rotation) {
+		this.options.rotation = rotation;
+		this.update();
 	},
 
 	_updateOpacity: function () {

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -87,6 +87,9 @@ L.Canvas = L.Renderer.extend({
 
 		// translate so we use the same path coordinates after canvas element moves
 		this._ctx.translate(-b.min.x, -b.min.y);
+
+		// Tell paths to redraw themselves
+		this.fire('update');
 	},
 
 	_initPath: function (layer) {

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -45,13 +45,10 @@ L.Renderer = L.Layer.extend({
 
 		this.getPane().appendChild(this._container);
 		this._update();
-
-		this._map.on('rotate', this._update, this);
 	},
 
 	onRemove: function () {
 		L.DomUtil.remove(this._container);
-		this._map.off('rotate', this._update, this);
 	},
 
 	getEvents: function () {
@@ -90,7 +87,8 @@ L.Renderer = L.Layer.extend({
 	},
 
 	_update: function () {
-		// update pixel bounds of renderer container (for positioning/sizing/clipping later)
+		// Update pixel bounds of renderer container (for positioning/sizing/clipping later)
+		// Subclasses are responsible of firing the 'update' event.
 		var p = this.options.padding,
 		    map = this._map,
 		    size = this._map.getSize(),
@@ -111,8 +109,6 @@ L.Renderer = L.Layer.extend({
 
 		this._center = this._map.getCenter();
 		this._zoom = this._map.getZoom();
-
-		this.fire('update');
 	}
 });
 

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -78,6 +78,8 @@ L.SVG = L.Renderer.extend({
 		// movement: update container viewBox so that we don't have to change coordinates of individual layers
 		L.DomUtil.setPosition(container, b.min);
 		container.setAttribute('viewBox', [b.min.x, b.min.y, size.x, size.y].join(' '));
+
+		this.fire('update');
 	},
 
 	// methods below are called by vector layers implementations


### PR DESCRIPTION
Currently I'm working on a webapp based on OpenLayers, displaying in-door map. However OpenLayers is too heavy and I need a lightweight map library. The original Leaflet doesn't support rotation, and I found your mods which works like a charm. Thanks!

However, it doesn't support rotated markers yet, which OpenLayers supports. So I modified the code, adding `rotation` and `rotateWithView` options, and `setRotation(rad)` method for Marker.

And BTW improved `L.Point.rotateFrom(theta, pivot)` 's performance.

[Demo](http://rawgit.com/laobubu/Leaflet/rotate-master/debug/rotate/rotated-marker.html)